### PR TITLE
Inject latest BYG page when trigger condition is met

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -67,7 +67,15 @@ function enqueue_frontend_scripts() : void {
 	register_build_asset(
 		'byg-frontend',
 		'before-you-go-frontend.js',
-		[]
+		/**
+		 * Allow a theme or plugin to integrate with this plugin by registering
+		 * a custom script as a dependency of our BYG frontend script. If the
+		 * dependency script defines a BYG global with a custom callback or
+		 * trigger, that will alter the behavior of the BYG activation.
+		 *
+		 * @param string[] $dependencies Script handles to load ahead of the frontend bundle.
+		 */
+		apply_filters( 'byg\script_dependencies', [] )
 	);
 
 	$inline_script = [

--- a/inc/post-types/byg-page.php
+++ b/inc/post-types/byg-page.php
@@ -35,29 +35,34 @@ function register_type() {
 		'search_items'        => esc_html__( 'Search Before You Go pages', 'byg-admin' ),
 		'not_found'           => esc_html__( 'No Before You Go page found', 'byg-admin' ),
 		'not_found_in_trash'  => esc_html__( 'No Before You Go page found in Trash', 'byg-admin' ),
-		'menu_name'           => esc_html__( 'Before You Go pages', 'byg-admin' ),
+		'menu_name'           => esc_html__( 'Before You Go', 'byg-admin' ),
 	];
 
 	$args = [
 		'labels'              => $labels,
 		'hierarchical'        => false,
 		'description'         => 'Before You Go pages are used to display customizable content to users leaving the site after visiting from social media.',
-		'public'              => false,
+		'public'              => true,
 		'show_ui'             => true,
 		'show_in_menu'        => true,
-		'show_in_admin_bar'   => true,
-		'menu_position'       => 5,
-		'menu_icon'           => 'dashicons-back',
+		'show_in_admin_bar'   => false,
+		'show_in_rest'        => true, // Enables block editor.
+		'menu_icon'           => 'dashicons-arrow-left',
 		'show_in_nav_menus'   => false,
-		'publicly_queryable'  => false,
+		'publicly_queryable'  => true,
 		'exclude_from_search' => true,
 		'has_archive'         => false,
-		'query_var'           => POST_TYPE,
+		'query_var'           => 'byg',
 		'capability_type'     => 'post',
 		'supports'            => [
 			'title',
 			'custom-fields',
 			'editor',
+		],
+		'rewrite' => [
+			'slug'       => 'byg',
+			'with_front' => false,
+			'pages'      => false,
 		],
 		/**
 		 * Permit filtering the list of taxonomies added to the BYG Page post types.

--- a/inc/post-types/byg-page.php
+++ b/inc/post-types/byg-page.php
@@ -76,3 +76,21 @@ function register_type() {
 
 	register_post_type( POST_TYPE, $args );
 }
+
+/**
+ * Return the URL of the most recent BYG item, if there is one.
+ *
+ * @return string|null Target URL, or null if no BYG target available.
+ */
+function get_latest_byg_permalink() : ?string {
+	$byg_post = get_posts( [
+		'post_type'   => POST_TYPE,
+		'numberposts' => 1,
+	] );
+
+	if ( empty( $byg_post ) ) {
+		return null;
+	}
+
+	return get_permalink( $byg_post[0] );
+}

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -1,14 +1,50 @@
 import { has as hasQuery } from './services/query';
 import { has as hasReferrer } from './services/referrer';
 
+/**
+ * BYG global object, mostly PHP-filterable.
+ *
+ * @typedef {object} BYG
+ * @property {string[]} referrers  Array of referrer trigger domains.
+ * @property {string[]} utmSources Array of utm_source trigger values.
+ * @property {boolean}  debug      Whether in debug mode.
+ * @property {Function} [trigger]  Trigger logic for BYG behavior.
+ * @property {Function} [callback] Callback to execute if trigger condition is met.
+ */
+
+/**
+ * Default trigger logic, if no other JS has configured a custom path.
+ *
+ * @param {BYG} BYG Before You Go window global object.
+ */
+const defaultTrigger = ( { referrers, utmSources, callback } ) => {
+	if ( hasQuery( 'utm_source', utmSources ) || hasReferrer( referrers ) ) {
+		callback();
+	}
+};
+
+/**
+ * Default callback to fire when BYG trigger condition is met.
+ */
+const defaultCallback = () => {
+	alert( 'BYG would initialize!' );
+};
+
 window.addEventListener( 'load', () => {
-	// Read in the BYG global values; ensure required arrays are present.
+	// Read in the BYG global values and ensure required arrays are present.
+	/** @type {BYG} */
 	const BYG = Object.assign( {
 		referrers: [],
 		utmSources: [],
 	}, window.BYG || {} );
 
-	if ( hasQuery( 'utm_source', BYG.utmSources ) || hasReferrer( BYG.referrers ) ) {
-		alert( 'BYG would initialize!' );
+	// Ensure trigger and callback are callable.
+	if ( typeof BYG.trigger !== 'function' ) {
+		BYG.trigger = defaultTrigger;
 	}
+	if ( typeof BYG.callback !== 'function' ) {
+		BYG.callback = defaultCallback;
+	}
+
+	BYG.trigger( BYG );
 } );

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -1,0 +1,16 @@
+const { history } = window;
+
+/**
+ * Insert a page into the history, by replacing the current page with the
+ * target and then pushing the current actual page again to create a virtual
+ * page "back" from the current one.
+ *
+ * @param {any}             data  Data to set in the injected page state.
+ * @param {string|URL|null} [url] URL of the history entry to inject.
+ */
+export const injectPage = ( data, url ) => {
+	const currentPage = window.location.href;
+
+	history.replaceState( data, '', url );
+	history.pushState( {}, '', currentPage );
+};


### PR DESCRIPTION
This PR sketches out a rough, page-reload approach for this project. At the moment we are trying out loading an individual new URL instead of rendering a frontend in JS, to give more rendering flexibility to the integrating site, but please challenge this—if there's a better way to achieve this functionality, we should discuss it.

## Current MVP architecture

- Define a "Before You Go" post type object, which can be used to create a custom page to edit the content which should be showed to a user.
    - For MVP, only the latest BYG page is used.
- Use JS to read both `utm_source` query parameter, and `document.referrer` browser global.
- If Twitter or Facebook are detected, `history.replaceState` and `history.pushState` are used to spoof a new page in the browser history (see `injectPage` function in JS)
    - Use `history.replaceState` to rewrite the _current_ URL of the page on which the trigger condition was met, to match the target BYG page. (This does not reload the page or trigger any navigation)
    - Use `history.pushState` to re-inject the current _actual_ page (e.g. `whatever-you-landed-on?utm_source=facebook`), which sets the URL back to the _actual_ current URL, but now thanks to the prior step there is a new page in the history that hasn't actually been visited.

Then, when the user clicks "back," they will be taken to the BYG page.

## Known Issues

- The biggest issue with this PR is that there's no logic to prevent this from firing multiple times. I'm not sure what AP, etc do for this, to be able to ensure the page isn't repeatedly re-injected. (If they address it at all)
- Rendering the BYG view as a separate page load ensures that all relevant tracking code will fire, but we don't currently have any mechanism to validate whether the BYG page is associated with Twitter or Facebook etc

As a final note, several developers have raised UX issues about this flow, on the grounds that it violates user's expectations about how the Back button works. We hear this, the project for which we're building this is aware of that issue, and the current position is that this is less invasive than an on-page modal, but we will continue to review whether this provides a positive or negative experience on the site.

## Background

The idea here is to mimic behavior seen on AP's site (and others) where a pseudo-page is injected into the browser history using JavaScript, which can be used to merchandise specific products, offer links for recirculation within the site, or promote any arbitrary content or message desired by the site editorial team.

This feature could drive recirculation through the site by displaying some combination of related posts, personalized callouts and widgets, or editorially-specified content.

### Example flow on AP

- User clicks a link from `@AP`'s twitter feed, and ends up on an article
- JS recognizes user has come from twitter, and injects a history state (activating the "back" button, which you can see 'light up' as the history state is inserted)
- When the user clicks the "back" button, JS acknowledges the interaction by displaying a pseudo-page (a JS-rendered modal blanket) to display a "before you go" view like the one below
- If the user closes the tab, it just closes, without argument
- If the user shares the URL from the "before you go," they get the same URL as the page they started on

<img width="1116" alt="image" src="https://user-images.githubusercontent.com/442115/217122687-e755af92-11ac-4acd-bbc1-b385dccfd835.png">
