### PR TITLE
Add a popstate listener to ensure the BYG page is loaded

### DIFF
--- a/src/services/history.js
+++ b/src/services/history.js
@@ -26,15 +26,14 @@ export const injectPage = ( data, url ) => {
 	 * @param {Window} event.target Window state after pop navigation.
 	 * @returns {Function}
 	 */
-	const onPopState = () => setTimeout(
-		( { target } ) => {
+	const onPopState = ( { target } ) =>
+		setTimeout( () => {
 			if ( target.location.href === url ) {
 				target.location.reload();
 			}
 
 			removeEventListener( 'popstate', onPopState );
-		}
-	);
+		} );
 
 	history.replaceState( data, '', url );
 	history.pushState( {}, '', currentPage );

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -24,9 +24,8 @@ export const injectPage = ( data, url ) => {
 	 *
 	 * @param {Event} event HTML popstate event triggered by back nutton navigation.
 	 * @param {Window} event.target Window state after pop navigation.
-	 * @returns {Function}
 	 */
-	const onPopState = ( { target } ) =>
+	const onPopState = ( { target } ) => {
 		setTimeout( () => {
 			if ( target.location.href === url ) {
 				target.location.reload();
@@ -34,6 +33,9 @@ export const injectPage = ( data, url ) => {
 
 			removeEventListener( 'popstate', onPopState );
 		} );
+
+		return;
+	};
 
 	history.replaceState( data, '', url );
 	history.pushState( {}, '', currentPage );

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -24,14 +24,17 @@ export const injectPage = ( data, url ) => {
 	 *
 	 * @param {Event} event HTML popstate event triggered by back nutton navigation.
 	 * @param {Window} event.target Window state after pop navigation.
+	 * @returns {Function}
 	 */
-	const onPopState = ( { target } ) => {
-		if ( target.location.href === url ) {
-			target.location.reload();
-		}
+	const onPopState = () => setTimeout(
+		( { target } ) => {
+			if ( target.location.href === url ) {
+				target.location.reload();
+			}
 
-		removeEventListener( 'popstate', onPopState );
-	};
+			removeEventListener( 'popstate', onPopState );
+		}
+	);
 
 	history.replaceState( data, '', url );
 	history.pushState( {}, '', currentPage );

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -1,4 +1,4 @@
-const { history } = window;
+const { history, addEventListener, removeEventListener } = window;
 
 /**
  * Insert a page into the history, by replacing the current page with the
@@ -11,6 +11,30 @@ const { history } = window;
 export const injectPage = ( data, url ) => {
 	const currentPage = window.location.href;
 
+	/**
+	 * Handle popstate navigation in browsers that don't allow access to it directly.
+	 *
+	 * Browsers have different behavior when it comes to reloading "virtual"
+	 * pageviews through their respective History APIs (see
+	 * https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API).
+	 * Some browsers, when navigating back to entries which exist in their
+	 * history, will reload from the URL, while others only update the location
+	 * bar and the state object. This function, run after the popstate event
+	 * occurs, ensures we get a new pageload rather than solely a location bar update.
+	 *
+	 * @param {Event} event HTML popstate event triggered by back nutton navigation.
+	 * @param {Window} event.target Window state after pop navigation.
+	 */
+	const onPopState = ( { target } ) => {
+		if ( target.location.href === url ) {
+			target.location.reload();
+		}
+
+		removeEventListener( 'popstate', onPopState );
+	};
+
 	history.replaceState( data, '', url );
 	history.pushState( {}, '', currentPage );
+
+	addEventListener( 'popstate', onPopState );
 };


### PR DESCRIPTION
Works around some inconsistencies in how different browsers/browser profiles handle navigation in response to history popstate events by ensuring that the desired URL is actually loaded rather than just reflected in the nav bar.