### PR TITLE
Scroll to top after popping Before You Go page

### DIFF
--- a/src/frontend.js
+++ b/src/frontend.js
@@ -38,7 +38,7 @@ const defaultTrigger = ( BYG ) => {
  * @param {BYG} BYG Before You Go window object.
  */
 const defaultCallback = ( { url } ) => {
-	if ( url ) {
+	if ( url && url !== window.location.href ) {
 		injectPage( {}, url );
 	}
 };

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -49,24 +49,24 @@ export const injectPage = ( data, bygUrl ) => {
 	 * bar and the state object. This function, run after the popstate event
 	 * occurs, ensures we get a new pageload rather than solely a location bar update.
 	 *
-	 * @param {Event} event HTML popstate event triggered by back nutton navigation.
+	 * @param {Event} event HTML popstate event triggered by back button navigation.
 	 * @param {Window} event.target Window state after pop navigation.
 	 */
-	const onPopState = ( { target } ) => {
+	const onPopState = ( { state: { isBackPage, isForwardPage } } ) => {
+
+		if ( ! ( isBackPage || isForwardPage ) ) {
+			return;
+		}
+
 		setTimeout( () => {
-			if ( [ bygUrl, currentPage ].includes( target.location.href ) ) {
-				target.location.reload();
-				window.scrollTo( 0, 0 );
-			}
-
-			removeEventListener( 'popstate', onPopState );
+			window.location.reload();
+			window.scrollTo( 0, 0 );
+			history.replaceState( {}, '', currentUrl );
 		} );
-
-		return;
 	};
 
-	history.replaceState( data, '', bygUrl );
-	history.pushState( {}, '', currentPage );
+	history.replaceState( { isBackPage: true }, '', bygUrl );
+	history.pushState( { isForwardPage: true }, '', currentUrl );
 
 	addEventListener( 'popstate', onPopState );
 };

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -29,6 +29,7 @@ export const injectPage = ( data, bygUrl ) => {
 		setTimeout( () => {
 			if ( [ bygUrl, currentPage ].includes( target.location.href ) ) {
 				target.location.reload();
+				window.scrollTo( 0, 0 );
 			}
 
 			removeEventListener( 'popstate', onPopState );

--- a/src/services/history.js
+++ b/src/services/history.js
@@ -1,4 +1,10 @@
-const { history, addEventListener, removeEventListener } = window;
+const { history, addEventListener, sessionStorage } = window;
+
+/**
+ * Store a value in session storage indicating whether the user has already
+ * been served a Before You Go! experience.
+ */
+const SESSION_STORAGE_KEY = 'beforeYouGo';
 
 /**
  * Insert a page into the history, by replacing the current page with the
@@ -9,7 +15,28 @@ const { history, addEventListener, removeEventListener } = window;
  * @param {string|URL|null} bygUrl URL of the history entry to inject.
  */
 export const injectPage = ( data, bygUrl ) => {
-	const currentPage = window.location.href;
+
+	/*
+	 * The landing page URL where the BYG page was injected from.
+	 *
+	 * @var string
+	 */
+	const currentUrl = window.location.href;
+
+	// After navigating backward and forward, clear the navigation
+	// hacks out of the history so history navigation works as usual.
+	if ( history.state && history.state.isForwardPage ) {
+		history.replaceState( {}, '', currentUrl );
+		window.location.reload();
+		return;
+	}
+
+	// Ensure that we're not injecting more than one item into history.
+	if ( sessionStorage.getItem( SESSION_STORAGE_KEY ) ) {
+		return;
+	}
+
+	sessionStorage.setItem( SESSION_STORAGE_KEY, bygUrl );
 
 	/**
 	 * Handle popstate navigation in browsers that don't allow access to it directly.


### PR DESCRIPTION
* Adds a "scroll to top" after loading the Before You Go page, so that the page content shows up in the expected space in the viewport.
* Uses a session storage flag to store whether a user has already been served a Before You Go page, to avoid inserting more than one page in a user's history.
* Try more intelligently to detect if a pageload event is the result of a BYG pseudo-page history entry, and reload the page and scroll to the top if so.