### PR TITLE
Avoid js TypeError when no BYG pages are configured

### DIFF
--- a/src/frontend.js
+++ b/src/frontend.js
@@ -27,9 +27,11 @@ import { injectPage } from './services/history';
 const defaultTrigger = ( BYG ) => {
 	const { callback, urls } = BYG;
 
-	BYG.url = getMatchingAudience( urls );
+	if ( callback && urls ) {
+		BYG.url = getMatchingAudience( urls );
 
-	callback( BYG );
+		callback( BYG );
+	}
 };
 
 /**
@@ -50,6 +52,7 @@ window.addEventListener( 'load', () => {
 	const BYG = Object.assign( {
 		referrers: [],
 		utmSources: [],
+		urls: [],
 	}, window.BYG || {} );
 
 	if ( typeof BYG.trigger === 'function' ) {


### PR DESCRIPTION
The `getMatchingAudiences()` function expects "urls" to be passed as an array, but if there are no URLs configured for the site, that value is null. 

This change sets a sensible default to avoid console warnings bootstrapping the BYG frontend.

![image](https://github.com/humanmade/before-you-go/assets/665992/3bfe5e00-e945-40b7-8ff8-17949fb25076)
